### PR TITLE
Update cnf.el

### DIFF
--- a/Emacs/cnf.el
+++ b/Emacs/cnf.el
@@ -703,10 +703,11 @@
       (puthash  (caddr x) (car x) xxx)))
 
 (defun cnf(xs)
+  "Surrounds unknown characters with !s and shows them in red bold font"
   (dolist (x xs)
     (let ((s (gethash x xxx)))
-       (if s (insert s)
-          (insert (format " %s" x)) )) ))
+      (if s (insert s)
+        (insert (propertize (format " !%s!" x) 'face '(:foreground "red" :weight bold))) )) ))
 
 (defmacro cn(&rest args)
   `(cnf ',args))


### PR DESCRIPTION
Surrounded the characters with !! to highlight the untransliterated characters in case the emacs configuration does not display the changed font in bold red (mine didn't; but after removing my .emacs and reloading cnf.el, function CNF worked as intended, displaying unknown characters to red bold).